### PR TITLE
Add function coordinate syntax to `rotate` function

### DIFF
--- a/draw.typ
+++ b/draw.typ
@@ -35,7 +35,16 @@
 #let rotate(angle) = {
   ((
     before: ctx => {
-      if type(angle) == "dictionary" {
+      let angle = angle
+      if type(angle) == "array" {
+        if type(angle.first()) == "function" {
+          angle = util.resolve-coordinate(ctx, angle)
+        }
+      }
+      if type(angle) == "angle" {
+        ctx.transform.do.push(matrix.transform-rotate-z(angle))
+        ctx.transform.undo.push(matrix.transform-rotate-z(-angle))
+      } else if type(angle) == "dictionary" {
         let (x, y, z) = (0deg, 0deg, 0deg)
         if "x" in angle { x = angle.x }
         if "y" in angle { y = angle.y }
@@ -43,8 +52,7 @@
         ctx.transform.do.push(matrix.transform-rotate-xyz(x, y, z))
         ctx.transform.undo.push(matrix.transform-rotate-xyz(-x, -y, -z))
       } else {
-        ctx.transform.do.push(matrix.transform-rotate-z(angle))
-        ctx.transform.undo.push(matrix.transform-rotate-z(-angle))
+        panic("Invalid angle format '" + repr(angle) + "'")
       }
       return ctx
     }


### PR DESCRIPTION
This is done by checking if the syntax is correct in the `rotate` function then passing it off to `resolve-coordinate`.