### PR TITLE
Allow `rel:` in `node:` coordinates

### DIFF
--- a/manual.typ
+++ b/manual.typ
@@ -70,6 +70,9 @@ There are four different ways to specify coordinates.
   + Anchor: `(node: "name", at: "example")` or `"name.example"` \
     "The position of anchor `"example"` on node with name `"name"`." \
     See @anchors
+  + Relative to anchor: `(node: "name", at "example", rel: (x,y))` \
+    "`x` units to the right and `y` units down from the position of anchor `"name"` on node `"example"`." \
+    See @anchors
   + Angle + Distance: `(45deg, 1)` \
     "Angle and distance from `(0, 0)`"
 

--- a/util.typ
+++ b/util.typ
@@ -42,6 +42,7 @@
   }
 
   if type(c) == "dictionary" {
+    let pos = none
     if "node" in c {
       assert(c.node in ctx.anchors,
              message: "Unknown node '" + c.node + "' in nodes " + repr(ctx.anchors))
@@ -58,15 +59,22 @@
       }
 
       // Anchors are absolute, we need to reverse transform them
-      return revert-transform(ctx.transform, anchor)
+      pos = revert-transform(ctx.transform, anchor)
     }
 
     // Add relative positions to previous position
     if "rel" in c {
-      return vector.add(ctx.prev.pt, vector.as-vec(c.rel))
+      if pos == none {
+        pos = ctx.prev.pt
+      }
+      pos = vector.add(pos, vector.as-vec(c.rel))
     }
 
-    panic("Invalid coordiantes: " + repr(c))
+    if pos == none {
+      panic("Invalid coordiantes: " + repr(c))
+    } else {
+      return pos
+    }
   }
 
   if type(c) == "array" {


### PR DESCRIPTION
First off, thanks for the awesome library! This is absolutely huge for Typst, and fills a huge gap.

In this PR, I made it so you can specify `(node: ..., at: ..., rel: (x, y))`, in order to succinctly specify a position relative to a node's anchor. (Right now, I have to place an empty content on the node to change the "last location" pointer to do that, which isn't very pretty, haha.) I tested this locally on my project, but you may wish to perform your own tests as well.
Feel free to change the implementation or syntax.

It should be good enough for now, **but** I think we shouldn't stop here - ideally, we should make `rel:` work with other kinds of coordinates too, or even have multiple of it. But we could discuss that better in an issue before making actual progress here.