### PR TITLE
Add padding around content blocks

### DIFF
--- a/canvas.typ
+++ b/canvas.typ
@@ -236,6 +236,9 @@
     // Previous element position & bbox
     prev: (pt: (0, 0, 0)),
 
+    // Current content padding size (added around content boxes)
+    content-padding: 0em,
+
     // Current draw attributes
     mark-size: .15,
     fill: none,

--- a/draw.typ
+++ b/draw.typ
@@ -265,7 +265,7 @@
   ct,
   angle: 0deg,
   anchor: none,
-  padding: none,
+  padding: auto,
   name: none
   ) = {
   let t = coordinate.resolve-system(pt)
@@ -277,7 +277,7 @@
     render: (ctx, pt) => {
       let (x, y, ..) = pt
 
-      let padding = util.resolve-number(ctx, if padding != none { padding } else { ctx.content-padding })
+      let padding = util.resolve-number(ctx, if padding == auto { ctx.content-padding } else { padding })
       let size = measure(ct, ctx.style)
       let tw = size.width / ctx.length 
       let th = size.height / ctx.length

--- a/draw.typ
+++ b/draw.typ
@@ -273,8 +273,8 @@
       let size = measure(ct, ctx.style)
       let tw = size.width / ctx.length 
       let th = size.height / ctx.length
-      let w = (calc.abs(calc.sin(angle) * th) + calc.abs(calc.cos(angle) * tw)) + padding
-      let h = (calc.abs(calc.cos(angle) * th) + calc.abs(calc.sin(angle) * tw)) + padding
+      let w = (calc.abs(calc.sin(angle) * th) + calc.abs(calc.cos(angle) * tw)) + padding * 2
+      let h = (calc.abs(calc.cos(angle) * th) + calc.abs(calc.sin(angle) * tw)) + padding * 2
 
       // x += w/2
       // y -= h/2

--- a/draw.typ
+++ b/draw.typ
@@ -256,6 +256,7 @@
   ct,
   angle: 0deg,
   anchor: none,
+  padding: 0.5em,
   name: none
   ) = {
   let t = coordinate.resolve-system(pt)
@@ -264,14 +265,16 @@
     coordinates: (pt,),
     anchor: anchor,
     default-anchor: "center",
+    padding: padding,
     render: (ctx, pt) => {
       let (x, y, ..) = pt
 
+      let padding = util.resolve-number(ctx, padding)
       let size = measure(ct, ctx.style)
-      let tw = size.width / ctx.length
+      let tw = size.width / ctx.length 
       let th = size.height / ctx.length
-      let w = (calc.abs(calc.sin(angle) * th) + calc.abs(calc.cos(angle) * tw))
-      let h = (calc.abs(calc.cos(angle) * th) + calc.abs(calc.sin(angle) * tw))
+      let w = (calc.abs(calc.sin(angle) * th) + calc.abs(calc.cos(angle) * tw)) + padding
+      let h = (calc.abs(calc.cos(angle) * th) + calc.abs(calc.sin(angle) * tw)) + padding
 
       // x += w/2
       // y -= h/2

--- a/draw.typ
+++ b/draw.typ
@@ -25,6 +25,15 @@
   ),)
 }
 
+#let content-padding(padding) = {
+  ((
+    before: ctx => {
+        ctx.content-padding = padding
+        return ctx
+      }
+  ),)
+}
+
 // Move to coordinate `pt`
 // @param pt coordinate
 #let move-to(pt) = {
@@ -256,7 +265,7 @@
   ct,
   angle: 0deg,
   anchor: none,
-  padding: 0.5em,
+  padding: none,
   name: none
   ) = {
   let t = coordinate.resolve-system(pt)
@@ -265,11 +274,10 @@
     coordinates: (pt,),
     anchor: anchor,
     default-anchor: "center",
-    padding: padding,
     render: (ctx, pt) => {
       let (x, y, ..) = pt
 
-      let padding = util.resolve-number(ctx, padding)
+      let padding = util.resolve-number(ctx, if padding != none { padding } else { ctx.content-padding })
       let size = measure(ct, ctx.style)
       let tw = size.width / ctx.length 
       let th = size.height / ctx.length


### PR DESCRIPTION
This PR adds the option of having padding around content() blocks, as per https://github.com/johannes-wolf/typst-canvas/issues/53#issue-1731344063.

Set via `content-padding(length)` or `content(..., padding: length)`.