### PR TITLE
Fix alignment

### DIFF
--- a/canvas.typ
+++ b/canvas.typ
@@ -330,15 +330,22 @@
     -bounds.t, 
     0
   )
-  box(stroke: if debug {green}, width: width, height: height, fill: background, {
-    for d in draw-cmds {
-      d.segments = d.segments.map(s => {
-        return (s.at(0),) + s.slice(1).map(v => {
-          return util.apply-transform(transform, v)
-            .slice(0,2).map(x => ctx.length * x)
+  box(
+    stroke: if debug {green}, 
+    width: width, 
+    height: height, 
+    fill: background, 
+    align(
+      top,
+      for d in draw-cmds {
+        d.segments = d.segments.map(s => {
+          return (s.at(0),) + s.slice(1).map(v => {
+            return util.apply-transform(transform, v)
+              .slice(0,2).map(x => ctx.length * x)
+          })
         })
-      })
-      (d.draw)(d)
-    }
-  })
+        (d.draw)(d)
+      }
+    )
+  )
 }))


### PR DESCRIPTION
Fixes #116 

With the code
```
#let drawing1 = cetz.canvas(debug: false, background: red, {
  import cetz.draw: *

  circle(())
  circle((1,1))
})

#let drawing2 = cetz.canvas(debug: false, background: blue, {
  import cetz.draw: *

  circle(())
  circle((2,2))
})

#stack(dir:ltr, align(horizon, drawing1), drawing2)
```
Before:
![image](https://github.com/johannes-wolf/typst-canvas/assets/34489450/ca66f5bc-e9ea-4e73-965f-909d957a3c9c)

After: 
![image](https://github.com/johannes-wolf/typst-canvas/assets/34489450/5330d27b-ac29-4db4-aa57-673b163828ee)
