### PR TITLE
coordinate: Implement anchor offset syntax

### DIFF
--- a/src/coordinate.typ
+++ b/src/coordinate.typ
@@ -53,28 +53,49 @@
 
 
 #let resolve-anchor(ctx, c) = {
-  // (name: <string>, anchor: <string> or <none>)
-  // "name.anchor"
+  // (name: <string>, anchor: <string> or <none>, offset: <int> or <none>)
+  // "name.anchor[+-]*"
   // "name"
 
-  let (name, anchor) = if type(c) == str {
+  // Count the number of + and - characters at the end of
+  // name, and return the name without the character and
+  // the offset as tuple.
+  let parse-offset(name) = {
+    let offset = 0
+    while name.len() > 1 {
+      if name.ends-with("+") {
+        offset += 1
+        name = name.slice(0, -1)
+      } else if name.ends-with("-") {
+        offset -= 1
+        name = name.slice(0, -1)
+      } else {
+        break
+      }
+    }
+    return (name, offset)
+  }
+
+  let (name, anchor, offset) = if type(c) == str {
     let parts = c.split(".")
     if parts.len() == 1 {
-      (parts.first(), "default")
+      (parts.first(), "default", 0)
     } else {
-      (parts.slice(0, -1).join("."), parts.last())
+      (parts.slice(0, -1).join("."), ..parse-offset(parts.last()))
     }
   } else {
-    (c.name, c.at("anchor", default: "default"))
+    (c.name, c.at("anchor", default: "default"), c.at("offset", default: 0))
   }
 
   // Check if node is known
-  assert(name in ctx.nodes, message: "Unknown element '" + name + "' in elements " + repr(ctx.nodes.keys()))
-  let node = ctx.nodes.at(name)
+  assert(name in ctx.nodes,
+    message: "Unknown element '" + name + "' in elements " + repr(ctx.nodes.keys()))
   // Check if anchor is known
-  assert(anchor in node.anchors, message: "Unknown anchor '" + anchor + "' in anchors " + repr(node.anchors.keys()) + " for node " + name)
+  let node = ctx.nodes.at(name)
+  assert(anchor in node.anchors,
+    message: "Unknown anchor '" + anchor + "' in anchors " + repr(node.anchors.keys()) + " for node " + name)
 
-  return util.revert-transform(
+  let pos = util.revert-transform(
     ctx.transform,
     if anchor != none {
       node.anchors.at(anchor)
@@ -82,6 +103,25 @@
       node.anchors.default
     }
   )
+
+  // Add the offset as offset in direction
+  // from node center to the current anchor.
+  if offset != 0 {
+    // TODO: This means, every node must/should have an center that
+    // is suitable for this operation which is not true for the new
+    // tikz like anchors. Maye we add an addidional anchor for this
+    // purpose? For arcs i.e. this should be the origin/segment-center.
+    let offset = if "center" in node.anchors {
+      vector.scale(vector.norm(vector.sub(
+        pos,
+        util.revert-transform(ctx.transform, node.anchors.center))),
+        offset * 1) // TODO: This should come from style or ctx!
+    } else { (0, 0, 0) } // TODO: Either do nothing or have a default direction?
+
+    pos = vector.add(pos, offset)
+  }
+
+  return pos
 }
 
 #let resolve-barycentric(ctx, c) = {

--- a/src/draw/grouping.typ
+++ b/src/draw/grouping.typ
@@ -67,6 +67,9 @@
 }
 
 #let anchor(name, position) = {
+  assert(not name.ends-with(regex("[-+]+")),
+    message: "Anchors must not end with '-' or '+'!")
+
   coordinate.resolve-system(position)
   return (ctx => {
     assert(


### PR DESCRIPTION
This implements an additional syntax for anchor coordinates:
  `"node.anchor[+-]*"`

Adding one or more "+" to the anchor offsets it in the direction from element center
to "node.anchor" multiplied by the number of "+" characters. The "-" character does the
same but in the opposite direction.

**Idea:** have an easy to use (short) syntax for offsetting from anchors to make placing
labels or annotations on objects.

The code currently has three TODOs:
- If the distance should be configurable: how? Via style or via an ctx setting? A reason to not using the style system is, that coordinates do not (and should not) know which element they belong to.
- Should we introduce a special "origin/center" anchor for the direction calculation?
- Should we have a default direction?

**Example:**
```typst
#cetz.canvas(length: 1cm, {
  import cetz.draw: *

  line((0,0), (4,1), name: "line")
  circle("line.end", radius: .25)
  circle("line.end+", radius: .25, stroke: green)
  circle("line.start+", radius: .25, stroke: red)
})
```

![image](https://github.com/johannes-wolf/cetz/assets/519002/531ed09f-fad3-4723-aa9e-45d6a9fa1f5d)
