### PR TITLE
plugin: A plug-in API

### DIFF
--- a/manual.typ
+++ b/manual.typ
@@ -904,6 +904,33 @@ All path decoration functions support the following style keys:
 
 #doc-style.parse-show-module("/src/lib/decorations/path.typ")
 
+=== Plug-Ins
+CeTZ supports plug-ins that get automatically called for each canvas.
+A plug-in can modify the initial state of a canvas by providing any of the
+callbacks `init` or `draw`.
+
+#doc-style.parse-show-module("/src/plugin.typ")
+
+==== Example
+```typsc
+plugin.register((
+  init: ctx => {
+    ctx.my-plugin-data = [Demo]
+    return ctx
+  },
+  draw: ctx => {
+    cetz.draw.set-style(stroke: blue)
+    cetz.draw.content((0,0), ctx.my-plugin-data)
+  }
+))
+...
+canvas({
+  // All plug-in's draw functions get automatically injected here
+  import draw: *
+  line((0,0), (1,1))
+})
+```
+
 ==== Styling
 
 ===== Default `brace` Style

--- a/manual.typ
+++ b/manual.typ
@@ -906,21 +906,22 @@ All path decoration functions support the following style keys:
 
 === Plug-Ins
 CeTZ supports plug-ins that get automatically called for each canvas.
-A plug-in can modify the initial state of a canvas by providing any of the
-callbacks `init` or `draw`.
+A plug-in can modify the initial state of a canvas by providing the
+`init` callbacks.
+
+Note that canvas uses Typst state for plug-in registration. If you set
+custom context data, take into account that the plugin might not have
+been registered yet! Custom elements requireing custom context data
+must not fail if the data is not there yet.
 
 #doc-style.parse-show-module("/src/plugin.typ")
 
 ==== Example
 ```typsc
 plugin.register((
-  init: ctx => {
-    ctx.my-plugin-data = [Demo]
-    return ctx
-  },
-  draw: ctx => {
+  init: () => {
     cetz.draw.set-style(stroke: blue)
-    cetz.draw.content((0,0), ctx.my-plugin-data)
+    cetz.draw.content((0,0), [I am a plug-in])
   }
 ))
 ...

--- a/src/canvas.typ
+++ b/src/canvas.typ
@@ -9,6 +9,9 @@
 
 #import util: typst-length
 
+/// CeTZ Library version
+#let version = version((0,2,0))
+
 /// Sets up a canvas for drawing on.
 ///
 /// - length (length,ratio): Used to specify what 1 coordinate unit is. If given a ratio, that ratio is relative to the containing elements width!
@@ -32,6 +35,7 @@
     message: "Canvas length must be != 0!")
 
   let ctx = (
+    version: version,
     typst-style: st,
     typst-location: loc,
     length: length,

--- a/src/canvas.typ
+++ b/src/canvas.typ
@@ -19,7 +19,7 @@
 /// - background (none,color): A color to be used for the background of the canvas.
 /// - debug (bool): Shows the bounding boxes of each element when `true`.
 /// -> content
-#let canvas(length: 1cm, debug: false, background: none, body) = plugins.display(plugins => locate(loc => layout(ly => style(st => {
+#let canvas(length: 1cm, debug: false, background: none, body) = locate(loc => layout(ly => style(st => {
   let body = body
   if body == none { body = () }
   assert(type(body) == array,
@@ -56,17 +56,14 @@
   )
 
   // Initialize plug-ins
-  let prefix = ()
-  for plugin in plugins {
+  let plugin-body = ()
+  for plugin in plugins.at(loc) {
     if "init" in plugin {
-      ctx = (plugin.init)(ctx)
-    }
-    if "draw" in plugin {
-      prefix += (plugin.draw)(ctx)
+      plugin-body += (plugin.init)()
     }
   }
 
-  let (ctx, bounds, drawables) = process.many(ctx, prefix + body)
+  let (ctx, bounds, drawables) = process.many(ctx, plugin-body + body)
   if bounds == none {
     return []
   }
@@ -144,4 +141,4 @@
       }, dx: x * length, dy: y * length)
     }
   }))
-}))))
+})))

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -1,6 +1,4 @@
-#let version = version((0,2,0))
-
-#import "canvas.typ": canvas
+#import "canvas.typ": canvas, version
 #import "draw.typ"
 #import "plugin.typ"
 

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -2,6 +2,7 @@
 
 #import "canvas.typ": canvas
 #import "draw.typ"
+#import "plugin.typ"
 
 // Expose utilities
 #import "vector.typ"

--- a/src/plugin.typ
+++ b/src/plugin.typ
@@ -4,14 +4,13 @@
 ///
 /// - plugin (dictionary): Plug-In object. A plug-in in must be a dictionary
 ///   which can have the following callbacks:
-///   / `init`: A function of the form `ctx => ctx` acception and returning a context. The returned context
-///     is used as thet canvas' context.
-///   / `draw`: A function of the form `ctx => element` that can return any number of CeTZ elements that
-///     get _prefixed_ to the canvas body. This can be used to set-up a default style by calling `set-style(...)`.
+///   / `init`: A function of the form `() => element` that can return any number of CeTZ elements that
+///     get _prefixed_ to the canvas body. This can be used to set-up a default style by calling `set-style(...)` or
+///     set custom context data using `set-ctx(...)`.
 #let register(plugin) = {
   assert.eq(type(plugin), dictionary,
     message: "Expected plug-in dictionary, got " + repr(plugin))
-  plugins.update(l => {
+  return plugins.update(l => {
     l.push(plugin)
     return l
   })

--- a/src/plugin.typ
+++ b/src/plugin.typ
@@ -1,0 +1,18 @@
+#let plugins = state("cetz-plugins", ())
+
+/// Register a plug-in to CeTZ's plug-in list
+///
+/// - plugin (dictionary): Plug-In object. A plug-in in must be a dictionary
+///   which can have the following callbacks:
+///   / `init`: A function of the form `ctx => ctx` acception and returning a context. The returned context
+///     is used as thet canvas' context.
+///   / `draw`: A function of the form `ctx => element` that can return any number of CeTZ elements that
+///     get _prefixed_ to the canvas body. This can be used to set-up a default style by calling `set-style(...)`.
+#let register(plugin) = {
+  assert.eq(type(plugin), dictionary,
+    message: "Expected plug-in dictionary, got " + repr(plugin))
+  plugins.update(l => {
+    l.push(plugin)
+    return l
+  })
+}


### PR DESCRIPTION
### Plug-Ins
This is a PoC of a plug-in API for cetz.

Other packages can register themselves as a plugin by providing a plug-in dictionary, which can contain callbacks to initialize a canvas.

Currently, a single callback is supported:
- `init: () => element`: Can return canvas elements that get prefixed to each canvas body

### Example
```
#let my-plugin = (
  init: () => {
    draw.set-style(stroke: blue)
    draw.content((0, 1), [Demo])
  }
)
#plugin.register(my-plugin)

#canvas({
  import draw: *
  // Renders the plug-ins content and sets the stroke to blue
  line((0,0), (1,1))
})

#canvas({
  // This just renders the plug-ins content
})
```

Because of how Typst `state` works, care has to be taken when relaying on custom context data of a plug-in.

### Alternative
We could also not rely on `state` and just accept a `plug-ins: (...)` list in `canvas`. This would have the benefit of being sure plug-ins are ready when the canvas gets drawn. This should be more performant, as with the state based solution, each canvas (could) get(s) drawn multiple times with different state values. Using `state.final(loc)` did not help.