### PR TITLE
shapes: Use decoration style

### DIFF
--- a/src/canvas.typ
+++ b/src/canvas.typ
@@ -6,6 +6,7 @@
 #import "styles.typ"
 #import "process.typ"
 #import "version.typ"
+#import "modifiers.typ"
 
 #import util: typst-length
 
@@ -66,6 +67,10 @@
       wave: wave,
       zigzag: zigzag,
       coil: coil,
+    ),
+    path-modifiers: (
+      linearize: modifiers.linearize,
+      wave: modifiers.wave,
     ),
   )
 

--- a/src/canvas.typ
+++ b/src/canvas.typ
@@ -62,15 +62,13 @@
     nodes: (:),
     // Group stack
     groups: (),
-    // Registeretd decoration functions
-    decorations: (
-      wave: wave,
-      zigzag: zigzag,
-      coil: coil,
-    ),
+    // Registeretd modifier functions
     path-modifiers: (
       linearize: modifiers.linearize,
       wave: modifiers.wave,
+      //zigzag: modifiers.zigzag,
+      //coil: modifiers.coil,
+      ticks: modifiers.ticks,
     ),
   )
 

--- a/src/canvas.typ
+++ b/src/canvas.typ
@@ -40,6 +40,8 @@
   assert(length / 1cm != 0,
     message: "Canvas length must be != 0!")
 
+  import "/src/lib/decorations.typ": wave, zigzag, coil
+
   let ctx = (
     version: version.version,
     length: length,
@@ -57,8 +59,14 @@
        (0, 0, .0, 1)),
     // Nodes, stores anchors and paths
     nodes: (:),
-    // group stack
+    // Group stack
     groups: (),
+    // Registeretd decoration functions
+    decorations: (
+      wave: wave,
+      zigzag: zigzag,
+      coil: coil,
+    ),
   )
 
   let (ctx, bounds, drawables) = process.many(ctx, body)

--- a/src/draw.typ
+++ b/src/draw.typ
@@ -1,4 +1,4 @@
-#import "draw/grouping.typ": intersections, group, anchor, copy-anchors, place-anchors, set-ctx, get-ctx, for-each-anchor, on-layer, place-marks, hide, floating
+#import "draw/grouping.typ": intersections, group, anchor, copy-anchors, place-anchors, set-ctx, get-ctx, for-each-anchor, on-layer, place-marks, hide, floating apply-modifier
 #import "draw/transformations.typ": set-transform, rotate, translate, scale, set-origin, move-to, set-viewport
 #import "draw/styling.typ": set-style, fill, stroke
 #import "draw/shapes.typ": circle, circle-through, arc, arc-through, mark, line, grid, content, rect, bezier, bezier-through, catmull, hobby, merge-path

--- a/src/draw.typ
+++ b/src/draw.typ
@@ -1,4 +1,4 @@
-#import "draw/grouping.typ": intersections, group, anchor, copy-anchors, place-anchors, set-ctx, get-ctx, for-each-anchor, on-layer, place-marks, hide, floating apply-modifier
+#import "draw/grouping.typ": intersections, group, anchor, copy-anchors, place-anchors, set-ctx, get-ctx, for-each-anchor, on-layer, place-marks, hide, floating, apply-modifier
 #import "draw/transformations.typ": set-transform, rotate, translate, scale, set-origin, move-to, set-viewport
 #import "draw/styling.typ": set-style, fill, stroke
 #import "draw/shapes.typ": circle, circle-through, arc, arc-through, mark, line, grid, content, rect, bezier, bezier-through, catmull, hobby, merge-path

--- a/src/draw/grouping.typ
+++ b/src/draw/grouping.typ
@@ -10,6 +10,7 @@
 #import "/src/anchor.typ" as anchor_
 #import "/src/matrix.typ"
 #import "/src/deps.typ"
+#import "/src/modifier.typ": apply-path-modifier
 #import deps.oxifmt: strfmt
 
 #import "transformations.typ": move-to
@@ -561,6 +562,34 @@
     return (
       ctx: ctx,
       drawables: drawables
+    )
+  },)
+}
+
+/// Apply one or more element modifiers
+///
+/// - modifier (string,function): Modifier name or function
+/// - body (element):
+/// - ..style (style):
+#let apply-modifier(modifier, body, close: false, ..style) = {
+  assert.eq(style.pos(), (),
+    message: "Unexpected positional argumnets.")
+
+  if type(modifier) != array {
+    modifier = (modifier,)
+  }
+
+  (ctx => {
+    let (ctx, drawables, ..) = process.many(ctx, util.resolve-body(ctx, body))
+
+    let style = styles.resolve(ctx.style, merge: style.named())
+    style.decoration = modifier
+
+    drawables = apply-path-modifier(ctx, style, drawables, close)
+
+    return (
+      ctx: ctx,
+      drawables: drawables,
     )
   },)
 }

--- a/src/draw/grouping.typ
+++ b/src/draw/grouping.typ
@@ -583,7 +583,7 @@
     let (ctx, drawables, ..) = process.many(ctx, util.resolve-body(ctx, body))
 
     let style = styles.resolve(ctx.style, merge: style.named())
-    style.decoration = modifier
+    style.modifier = modifier
 
     drawables = apply-path-modifier(ctx, style, drawables, close)
 

--- a/src/draw/shapes.typ
+++ b/src/draw/shapes.typ
@@ -40,7 +40,7 @@
 
 // Apply path decoration to drawables
 #let _apply-decoration(ctx, style, drawables, close) = {
-  return modifier.apply-path-modifier(ctx, style, drawables, close).first()
+  return modifier.apply-path-modifier(ctx, style, drawables, close)
 }
 
 /// Draws a circle or ellipse.

--- a/src/draw/shapes.typ
+++ b/src/draw/shapes.typ
@@ -15,6 +15,7 @@
 #import "/src/mark.typ" as mark_
 #import "/src/mark-shapes.typ" as mark-shapes_
 #import "/src/aabb.typ"
+#import "/src/modifier.typ"
 
 #import "transformations.typ": *
 #import "styling.typ": *
@@ -38,25 +39,8 @@
 }
 
 // Apply path decoration to drawables
-#let _apply-decoration(ctx, style, drawables) = {
-  let deco = style.at("decoration", default: none)
-
-  if deco != none {
-    import "/src/lib/decorations.typ": wave, zigzag, coil
-    assert(type(deco) in (str, function),
-      message: "Decoration must be of type string or function")
-
-    let fn = if type(deco) == str {
-      ctx.decorations.at(deco)
-    } else if type(deco) == function {
-      deco
-    }
-
-    assert(fn != none,
-      message: "Decoration function is none")
-    return _apply-decoration-fn(ctx, style, drawables, fn)
-  }
-  return drawables
+#let _apply-decoration(ctx, style, drawables, close) = {
+  return modifier.apply-path-modifier(ctx, style, drawables, close).first()
 }
 
 /// Draws a circle or ellipse.
@@ -102,7 +86,7 @@
       stroke: style.stroke
     )
 
-    drawables = _apply-decoration(ctx, style, drawables)
+    drawables = _apply-decoration(ctx, style, drawables, true)
 
     let (transform, anchors) = anchor_.setup(
       (_) => pos,
@@ -177,7 +161,7 @@
       stroke: style.stroke
     )
 
-    drawables = _apply-decoration(ctx, style, drawables)
+    drawables = _apply-decoration(ctx, style, drawables, true)
 
     let (transform, anchors) = anchor_.setup(
       (anchor) => (
@@ -296,7 +280,7 @@
       mode: style.mode
     )
 
-    drawables = _apply-decoration(ctx, style, drawables)
+    drawables = _apply-decoration(ctx, style, drawables, false)
 
     let sector-center = (
       x - rx * calc.cos(start-angle),
@@ -612,7 +596,7 @@
     )
 
     // Apply decoration
-    drawables = _apply-decoration(ctx, style, drawables)
+    drawables = _apply-decoration(ctx, style, drawables, close)
 
     // Get bounds
     let (transform, anchors) = anchor_.setup(
@@ -929,7 +913,7 @@
 
     let drawables = ()
     if style.frame != none {
-      border = _apply-decoration(ctx, style, border)
+      border = _apply-decoration(ctx, style, border, true)
       drawables.push(border)
     }
 
@@ -1159,7 +1143,7 @@
         drawable.path(segments, fill: style.fill, stroke: style.stroke, close: true)
       }
 
-      drawables = _apply-decoration(ctx, style, drawables)
+      drawables = _apply-decoration(ctx, style, drawables, true)
 
       // Calculate border anchors
       let center = vector.lerp(a, b, .5)
@@ -1244,7 +1228,7 @@
         stroke: style.stroke,
       )
 
-      drawables = _apply-decoration(ctx, style, drawables)
+      drawables = _apply-decoration(ctx, style, drawables, false)
 
       let (transform, anchors) = anchor_.setup(
         anchor => (
@@ -1349,7 +1333,7 @@
       stroke: style.stroke,
       close: close)
 
-    drawables = _apply-decoration(ctx, style, drawables)
+    drawables = _apply-decoration(ctx, style, drawables, close)
 
     let (transform, anchors) = {
       let a = for (i, pt) in pts.enumerate() {
@@ -1430,7 +1414,7 @@
       stroke: style.stroke,
       close: close)
 
-    drawables = _apply-decoration(ctx, style, drawables)
+    drawables = _apply-decoration(ctx, style, drawables, close)
 
     let (transform, anchors) = {
       let a = for (i, pt) in pts.enumerate() {
@@ -1522,7 +1506,7 @@
       let style = styles.resolve(ctx.style, merge: style)
       let drawables = drawable.path(fill: style.fill, stroke: style.stroke, close: close, segments)
 
-      drawables = _apply-decoration(ctx, style, drawables)
+      drawables = _apply-decoration(ctx, style, drawables, close)
 
       let (transform, anchors) = anchor_.setup(
         auto,

--- a/src/draw/transformations.typ
+++ b/src/draw/transformations.typ
@@ -3,6 +3,7 @@
 #import "/src/vector.typ"
 #import "/src/util.typ"
 
+
 // Utility for applying translation to and from
 // the origin to apply a transformation matrix to.
 //

--- a/src/modifier.typ
+++ b/src/modifier.typ
@@ -1,7 +1,15 @@
 #import "/src/path-util.typ"
 
 /// A path modifier is a function that accepts a contex, style and
-/// a single drawable and returns a single (modifierd) drawable.
+/// a single drawable and returns a single (modified) drawable.
+///
+/// Example:
+/// ```typ
+/// (ctx, style, drawable) => {
+///   // ... modify the drawable ...
+///   return drawable
+/// }
+/// ```
 
 // Function for slicing a path into three parts,
 // a head, a mid section and a tail.

--- a/src/modifier.typ
+++ b/src/modifier.typ
@@ -1,0 +1,99 @@
+#import "/src/path-util.typ"
+
+/// A path modifier is a function that accepts a contex, style and
+/// a single drawable and returns a single (modifierd) drawable.
+
+// Function for slicing a path into three parts,
+// a head, a mid section and a tail.
+#let slice-segments(segments, start, end) = {
+  let len = path-util.length(segments)
+  if type(start) == ratio {
+    start = len * start / 100%
+  }
+  if type(end) == ratio {
+    end = len * end / 100%
+  }
+
+  let (head, mid, tail) = ((), segments, ())
+
+  if start != 0 or end != len {
+    mid = path-util.shorten-path(segments, start, end)
+  }
+
+  if start != 0 {
+    head = path-util.shorten-path(segments, 0, len - start)
+  }
+
+  if end != len {
+    tail = path-util.shorten-path(segments, len - end, 0)
+  }
+
+  return (head, mid, tail)
+}
+
+/// Apply a path modifier to a list of drawables
+///
+/// - ctx (context):
+/// - style (style):
+/// - elem (element): Single element
+#let apply-modifier-fn(ctx, style, elem, fn, close) = {
+  assert(type(fn) == function,
+    message: "Path modifier must be of type function.")
+
+  if "segments" in elem {
+    let begin = style.at("begin", default: 0%)
+    let end = style.at("end", default: 0%)
+
+    let (head, mid, tail) = slice-segments(elem.segments, begin, end)
+    let close = close and head == () and tail == ()
+    elem.segments = head + (fn)(ctx, style, mid, close) + tail
+  }
+
+  return elem
+}
+
+/// Apply a path modifier to a list of drawables
+#let apply-path-modifier(ctx, style, drawables, close) = {
+  if type(drawables) != array {
+    drawables = (drawables,)
+  }
+
+  let fns = if type(style.decoration) == array {
+    style.decoration
+  } else {
+    (style.decoration,)
+  }.map(n => {
+    let name = if type(n) == dictionary {
+      n.name
+    } else {
+      n
+    }
+
+    let extra-style = if type(n) == dictionary {
+      n
+    } else {
+      (:)
+    }
+
+    let fn = if type(name) == str {
+      assert(name in ctx.path-modifiers,
+        message: "Unknown path-modifier: " + repr(n))
+      ctx.path-modifiers.at(name)
+    } else {
+      name
+    }
+
+    (fn: fn, style: style + extra-style)
+  })
+
+  // Unset decorations to prevent unwanted recursion
+  style.decoration = ()
+
+  // Apply function on all drawables
+  return drawables.map(d => {
+    for fn in fns.filter(v => v.fn != none) {
+      d = apply-modifier-fn(ctx, fn.style, d, fn.fn, close)
+    }
+    return d
+  })
+}

--- a/src/modifier.typ
+++ b/src/modifier.typ
@@ -66,10 +66,10 @@
     drawables = (drawables,)
   }
 
-  let fns = if type(style.decoration) == array {
-    style.decoration
+  let fns = if type(style.modifier) == array {
+    style.modifier
   } else {
-    (style.decoration,)
+    (style.modifier,)
   }.map(n => {
     let name = if type(n) == dictionary {
       n.name
@@ -94,8 +94,8 @@
     (fn: fn, style: style + extra-style)
   })
 
-  // Unset decorations to prevent unwanted recursion
-  style.decoration = ()
+  // Unset modifiers to prevent unwanted recursion
+  style.modifier = ()
 
   // Apply function on all drawables
   return drawables.map(d => {

--- a/src/modifiers.typ
+++ b/src/modifiers.typ
@@ -1,0 +1,116 @@
+#import "/src/styles.typ"
+#import "/src/path-util.typ"
+#import "/src/bezier.typ" as bezier_
+#import "/src/vector.typ"
+
+// Call callback `fn` for each decoration segment
+// on path `segments`.
+//
+// The callback gets called with the following arguments:
+//   - i Segment index
+//   - start Segment start point
+//   - end Segment end point
+//   - norm Normal vector (length 1)
+// Result values get returned as an array
+#let _n-segment-effect(ctx, segments, fn, close: false, style) = {
+  let n = style.at("segments", default: 10)
+  assert(n > 0,
+    message: "Number of segments must be greater than 0")
+
+  let inc = 100% / n
+  let pts = ()
+  let len = path-util.length(segments)
+  for i in range(0, n) {
+    let p0 = path-util.point-on-path(segments, calc.max(0%,
+      inc * i))
+    let p1 = path-util.point-on-path(segments, calc.min(100%,
+      inc * (i + 1)))
+    if p0 == p1 { continue }
+
+    let dir = vector.sub(p1, p0)
+    let norm = vector.norm(vector.cross(dir, if p0.at(2) != p1.at(2) {
+      style.at("z-up", default: (0, 1, 0))
+    } else {
+      style.at("xy-up", default: (0, 0, -1))
+    }))
+
+    pts += fn(i, p0, p1, norm)
+  }
+  return pts
+}
+
+
+#let linearize-default-style = (
+  samples: 3,
+)
+
+/// Path modifier that linearizes bezier segments
+/// by sampling n points along the curve.
+#let linearize(ctx, style, segments, close) = {
+  let style = styles.resolve(ctx.style, merge: style,
+    base: linearize-default-style)
+  let samples = calc.max(2, int(style.samples))
+
+  let new = ()
+  for s in segments {
+    let kind = s.first()
+    if kind == "cubic" {
+      let pts = s.slice(1)
+      new.push(path-util.line-segment(range(0, samples).map(i => {
+        let t = calc.min(1, 1 / (samples - 1) * i)
+        bezier_.cubic-point(..pts, t)
+      })))
+    } else {
+      new.push(s)
+    }
+  }
+  return new
+}
+
+
+#let wave-default-style = (
+  tension: .5,
+  amplitude: 1,
+  segments: 10,
+)
+
+// Draw a wave along a path using a catmull-rom curve
+#let wave(ctx, style, segments, close) = {
+  let style = styles.resolve(ctx.style, merge: style,
+    base: wave-default-style)
+  let num-segments = style.segments
+
+  // Return a list of points for the catmull-rom curve
+  //
+  //   ╭ ma ╮        ▲
+  //   │    │        │ Up
+  // ..a....m....b.. '
+  //        │    │
+  //        ╰ mb ╯
+  //
+  let fn(i, a, b, norm) = {
+    let ab = vector.sub(b, a)
+    let up = vector.scale(norm, style.amplitude / 2)
+    let down = vector.scale(
+      up, -1)
+
+    let ma = vector.add(vector.add(a, vector.scale(ab, .25)), up)
+    let m  = vector.add(a, vector.scale(ab, .50))
+    let mb = vector.add(vector.sub(b, vector.scale(ab, .25)), down)
+
+    if not close {
+      if i == 0 {
+        return (a, ma, mb)
+      } else if i == num-segments - 1 {
+        return (ma, mb, b,)
+      }
+    }
+
+    return (ma, mb)
+  }
+
+  let pts = _n-segment-effect(ctx, segments, fn, style, close: close)
+  return bezier_.catmull-to-cubic(pts, style.tension, close: close).map(c => {
+    path-util.cubic-segment(..c)
+  })
+}

--- a/src/styles.typ
+++ b/src/styles.typ
@@ -9,10 +9,9 @@
   //   - "CURVED" Preserving the bezier curve by calculating new control points
   shorten: "LINEAR",
 
-  // Path decorations:
-  //   - Named decoration: "wave",
-  //   - Decoration function taking a path
-  decoration: none,
+  // Path modifier:
+  //   - Named modifier: "wave",
+  //   - Modifier function taking a path
   modifier: (:),
   
   // Allowed values:
@@ -66,7 +65,7 @@
     radius: auto,
     stroke: auto,
     fill: auto,
-    decoration: auto,
+    modifier: auto,
   ),
   group: (
     padding: auto,
@@ -77,14 +76,14 @@
     mark: auto,
     fill: auto,
     stroke: auto,
-    decoration: auto,
+    modifier: auto,
   ),
   bezier: (
     stroke: auto,
     fill: auto,
     mark: auto,
     shorten: auto,
-    decoration: auto,
+    modifier: auto,
   ),
   catmull: (
     tension: .5,
@@ -92,7 +91,7 @@
     shorten: auto,
     stroke: auto,
     fill: auto,
-    decoration: auto,
+    modifier: auto,
   ),
   hobby: (
     /// Curve start and end omega (curlyness)
@@ -101,7 +100,7 @@
     shorten: auto,
     stroke: auto,
     fill: auto,
-    decoration: auto,
+    modifier: auto,
   ),
   rect: (
     /// Rect corner radius that supports the following types:
@@ -117,7 +116,7 @@
     radius: 0,
     stroke: auto,
     fill: auto,
-    decoration: auto,
+    modifier: auto,
   ),
   arc: (
     // Supported values:
@@ -130,7 +129,7 @@
     stroke: auto,
     fill: auto,
     radius: auto,
-    decoration: auto,
+    modifier: auto,
   ),
   content: (
     padding: auto,
@@ -141,7 +140,7 @@
     frame: none,
     fill: auto,
     stroke: auto,
-    decoration: auto,
+    modifier: auto,
   ),
 )
 

--- a/src/styles.typ
+++ b/src/styles.typ
@@ -4,10 +4,15 @@
   fill: none,
   stroke: black + 1pt,
   radius: 1,
-  /// Bezier shortening mode:
-  ///   - "LINEAR" Moving the affected point and it's next control point (like TikZ "quick" key)
-  ///   - "CURVED" Preserving the bezier curve by calculating new control points
+  // Bezier shortening mode:
+  //   - "LINEAR" Moving the affected point and it's next control point (like TikZ "quick" key)
+  //   - "CURVED" Preserving the bezier curve by calculating new control points
   shorten: "LINEAR",
+
+  // Path decorations:
+  //   - Named decoration: "wave",
+  //   - Decoration function taking a path
+  decoration: none,
   
   // Allowed values:
   //   - none

--- a/src/styles.typ
+++ b/src/styles.typ
@@ -13,6 +13,7 @@
   //   - Named decoration: "wave",
   //   - Decoration function taking a path
   decoration: none,
+  modifier: (:),
   
   // Allowed values:
   //   - none
@@ -64,7 +65,8 @@
   circle: (
     radius: auto,
     stroke: auto,
-    fill: auto
+    fill: auto,
+    decoration: auto,
   ),
   group: (
     padding: auto,
@@ -75,19 +77,22 @@
     mark: auto,
     fill: auto,
     stroke: auto,
+    decoration: auto,
   ),
   bezier: (
     stroke: auto,
     fill: auto,
     mark: auto,
     shorten: auto,
+    decoration: auto,
   ),
   catmull: (
     tension: .5,
     mark: auto,
     shorten: auto,
     stroke: auto,
-    fill: auto
+    fill: auto,
+    decoration: auto,
   ),
   hobby: (
     /// Curve start and end omega (curlyness)
@@ -95,7 +100,8 @@
     mark: auto,
     shorten: auto,
     stroke: auto,
-    fill: auto
+    fill: auto,
+    decoration: auto,
   ),
   rect: (
     /// Rect corner radius that supports the following types:
@@ -111,6 +117,7 @@
     radius: 0,
     stroke: auto,
     fill: auto,
+    decoration: auto,
   ),
   arc: (
     // Supported values:
@@ -122,7 +129,8 @@
     mark: auto,
     stroke: auto,
     fill: auto,
-    radius: auto
+    radius: auto,
+    decoration: auto,
   ),
   content: (
     padding: auto,
@@ -133,6 +141,7 @@
     frame: none,
     fill: auto,
     stroke: auto,
+    decoration: auto,
   ),
 )
 


### PR DESCRIPTION
Implements #465.

This PR is a WIP implementation on how to implement decorations as style option for all (but grid and mark) elements.

The idea:
- The context has a `decorations` dictionary that can be modified to add custom decorations.
  This allows for a function like `register-decoration(...)` for plug-ins (same plan as with custom marks; not added yet).
- The user can either use a decoration name (dict) or pass a function to `decoration: ..` for elements. Element paths get decorated _before_ adding marks, which allows for styled paths to have marks.
- You can still use decoration-functions via composition.
- You can apply multiple decorations in sequence
- Decorations can be applied on a subsection of a path (start, end)
- This API will replace the current decoration lib
- It works without destroying marks

Demo of the `wave` and `linearize` modifiers:
![grafik](https://github.com/cetz-package/cetz/assets/519002/adf19988-9cfe-48a1-a350-ce6bf81afc04)
