### PR TITLE
debug: Tag debug shapes

### DIFF
--- a/src/draw/shapes.typ
+++ b/src/draw/shapes.typ
@@ -1452,7 +1452,7 @@
             }
           }
           for drawable in r.drawables {
-            if drawable.hidden { continue }
+            if drawable.hidden or "debug" in drawable { continue }
             assert.eq(drawable.type, "path")
             segments += drawable.segments
           }

--- a/src/drawable.typ
+++ b/src/drawable.typ
@@ -30,7 +30,7 @@
   }
 }
 
-#let path(close: false, fill: none, stroke: none, segments) = {
+#let path(close: false, fill: none, stroke: none, segments, debug: false) = {
   let segments = segments
   // Handle case where only one segment has been passed
   if type(segments.first()) == str {
@@ -53,7 +53,9 @@
     stroke: stroke,
     hidden: false,
     bounds: true,
-  )
+  ) + if debug {
+    (debug: true)
+  }
 }
 
 #let content(pos, width, height, border, body) = {

--- a/src/process.typ
+++ b/src/process.typ
@@ -44,7 +44,8 @@
         (bounds.low.at(0), bounds.high.at(1), 0)
       )),
       stroke: red,
-      close: true
+      close: true,
+      debug: true,
     ))
   }
 


### PR DESCRIPTION
Tag debug paths as such and skip them in `merge-path`.

Debug shapes bring other problems, maybe we should remove the feature or remove documentation about it.

Fixes #575 