### PR TITLE
Fix broken marks table

### DIFF
--- a/docs/basics/marks.mdx
+++ b/docs/basics/marks.mdx
@@ -16,7 +16,7 @@ Marks are arrow tips that can be added to the end of path based elements that su
     let name-to-mnemonic = (:)
     for (name, item) in cetz.mark-shapes.mnemonics {
       let list = name-to-mnemonic.at(item.at(0), default: ())
-      list += (raw(name) + if item.at(1) { " (reversed)" },)
+      list += (raw(name) + if item.at(1).at("reverse", default: false) { " (reversed)" },)
       name-to-mnemonic.insert(item.at(0), list)
     }
     (


### PR DESCRIPTION
`mark-shapes.mnemonics` layout was changed, but it wasn't updated in the docs... This isn't essential to releasing cetz as it shouldn't be part of what is submitted to Universe. I've built the docs site off this branch though