### PR TITLE
Use `handle_cbor` for `aabb_func`

### DIFF
--- a/cetz-core/src/lib.rs
+++ b/cetz-core/src/lib.rs
@@ -152,13 +152,7 @@ struct AabbArgs {
 
 #[wasm_func]
 pub fn aabb_func(input: &[u8]) -> Result<Vec<u8>, String> {
-    match from_reader::<AabbArgs, _>(input) {
-        Ok(input) => {
-            let mut buf = Vec::new();
-            let bounds = aabb(input.init, input.pts)?;
-            into_writer(&bounds, &mut buf).unwrap();
-            Ok(buf)
-        }
-        Err(e) => Err(e.to_string()),
-    }
+    handle_cbor(input, |args: AabbArgs| {
+        aabb(args.init, args.pts)
+    })
 }

--- a/src/aabb.typ
+++ b/src/aabb.typ
@@ -1,4 +1,5 @@
 #import "vector.typ"
+#import "wasm.typ": call_wasm
 #let cetz-core = plugin("../cetz-core/cetz_core.wasm")
 
 /// Compute an axis aligned bounding box (aabb) for a list of <Type>vectors</Type>.
@@ -7,10 +8,7 @@
 /// - init (aabb): Initial aabb
 /// -> aabb
 #let aabb(pts, init: none) = {
-  let args = (pts: pts, init: init)
-  let encoded = cbor.encode(args)
-  let bounds = cbor(cetz-core.aabb_func(encoded))
-  return bounds
+  return call_wasm(cetz-core.aabb_func, (pts: pts, init: init))
 }
 
 /// Get the mid-point of an AABB as vector.

--- a/src/bezier.typ
+++ b/src/bezier.typ
@@ -2,6 +2,7 @@
 // Many functions are ports from https://github.com/Pomax/bezierjs
 #import "vector.typ"
 #import "aabb.typ"
+#import "wasm.typ": call_wasm
 
 #let cetz-core = plugin("../cetz-core/cetz_core.wasm")
 
@@ -397,9 +398,7 @@
 /// -> array
 #let cubic-extrema(s, e, c1, c2) = {
   let args = (s: s, e: e, c1: c1, c2: c2)
-  let encoded = cbor.encode(args)
-  let decoded = cbor(cetz-core.cubic_extrema_func(encoded))
-  decoded
+  return call_wasm(cetz-core.cubic_extrema_func, args)
 }
 
 /// Returns axis aligned bounding box coordinates `(bottom-left, top-right)` for a cubic bezier curve.

--- a/src/matrix.typ
+++ b/src/matrix.typ
@@ -1,4 +1,6 @@
 #import "vector.typ"
+#import "wasm.typ": call_wasm
+#let cetz-core = plugin("../cetz-core/cetz_core.wasm")
 
 // Global rounding precision
 #let precision = 8

--- a/src/wasm.typ
+++ b/src/wasm.typ
@@ -1,0 +1,11 @@
+/// These functions are not in `util.typ` to avoid circular imports.
+
+/// Call a wasm function with the given arguments and return the result.
+///
+/// - func (function): The wasm function to call.
+/// - args (dictionary): The arguments to pass to the function.
+/// -> any
+#let call_wasm(func, args) = {
+  let encoded = cbor.encode(args)
+  cbor(func(encoded))
+}


### PR DESCRIPTION
A small simplification for `aabb_func`. 

Also I've introduced a helper function inside Typst that might be cleaner? Let me know what you think @johannes-wolf. If you don't like it I can turn it back.