### PR TITLE
fix: don't evaluate callback twice in get-ctx

### DIFF
--- a/src/draw/grouping.typ
+++ b/src/draw/grouping.typ
@@ -491,7 +491,7 @@
   (ctx => {
     let body = callback(ctx)
     if body != none {
-      let (ctx, drawables) = process.many(ctx, callback(ctx))
+      let (ctx, drawables) = process.many(ctx, body)
       return (ctx: ctx, drawables: drawables)
     }
     return (ctx: ctx)


### PR DESCRIPTION
Just a small thing I spotted. This doesn't affect cetz, but does affect the number of times sampled values appear in an ide.