### PR TITLE
Add matrix.transform-rotate-aer (azimuth/elevation/roll) helper

### DIFF
--- a/src/matrix.typ
+++ b/src/matrix.typ
@@ -180,7 +180,7 @@
   let rotate-azimuth = transform-rotate-z(-90deg - azimuth)
   let (ax, ay, az) = (-sin(azimuth), cos(azimuth), 0)
   let rotate-elevation = _rotate-axis-angle(ax, ay, az, elevation)
-  let base = mul-mat(ident(4), rotate-z-up, rotate-azimuth, rotate-elevation)
+  let base = mul-mat(rotate-z-up, rotate-azimuth, rotate-elevation)
 
   if roll == 0deg {
     return base
@@ -189,7 +189,7 @@
   // Roll around the current viewing axis after azimuth/elevation.
   let (vx, vy, vz) = vector.norm(mul4x4-vec3(base, (1, 0, 0), w: 0))
   let rotate-roll = _rotate-axis-angle(vx, vy, vz, roll)
-  mul-mat(ident(4), rotate-roll, base)
+  mul-mat(rotate-roll, base)
 }
 
 // Return 4x4 rotate xz matrix


### PR DESCRIPTION
This PR adds a convenience rotation constructor to `matrix`:

`transform-rotate-aer(azimuth, elevation, roll: 0deg)`

## Behavior
- Builds a 4x4 rotation matrix from azimuth/elevation with optional roll.
- Uses the viewing convention:
  - `z` points up
  - `x` points toward the viewer
  - aligned with the common azimuth/elevation camera interpretation used by plotting tools (including matplotlib).
- Optional roll around the current viewing axis after azimuth/elevation.

## Implementation
- Added internal helper:
  - `_rotate-axis-angle(ax, ay, az, angle)` (axis-angle rotation matrix using the Rodrigues' formula)
- Added public function:
  - `transform-rotate-aer(azimuth, elevation, roll: 0deg)`