### PR TITLE
Feature: expose module name

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -22,3 +22,6 @@
 #import "lib/angle.typ"
 #import "lib/tree.typ"
 #import "lib/decorations.typ"
+
+// expose name
+#let name = "cetz"


### PR DESCRIPTION
For interaction with other packages it would be fruitful to expose the package name, such that we can easily identify modules, which is otherwise quite cumbersome (via module layout and function matching)

E.g. i would like to integrate a feature in touying where we could have easier access to animate cetz canvases:
`reduce(cetz)` instead of explicit bindings the user has to specify upfront.

Inside `reduce` we could then hide the binding logic.

See https://github.com/touying-typ/touying/issues/302 
