### PR TITLE
Fix broken assertion in `matrix.diag`

### DIFF
--- a/src/matrix.typ
+++ b/src/matrix.typ
@@ -44,7 +44,7 @@
 /// -> matrix
 #let diag(..diag) = {
   assert(diag.pos().len() >= 1, message: "Invalid dimension")
-  assert.eq(diag.named(), (), messaged: "Unexpected named argument")
+  assert.eq(diag.named(), (:), message: "Unexpected named argument")
 
   let diag = diag.pos()
   range(0, diag.len()).map(m => range(0, diag.len()).map(n => {


### PR DESCRIPTION
The `matrix.diag` function is currently unusable because of a couple typos in the assertion. It compares against an array instead of a dictionary (causing it to always fail the assertion), and there's a typo in the named argument (causing the assertion itself to error).

The line could alternatively be written as `assert(diag.named().len() == 0, ...` for consistency with the previous line, but I opted to edit it as minimally as possible.