### PR TITLE
Fix small typo/formatting issue in assertion in hobby/catmul

### DIFF
--- a/src/draw/shapes.typ
+++ b/src/draw/shapes.typ
@@ -1692,7 +1692,7 @@
 #let catmull(..pts-style, close: false, name: none) = {
   let (pts, style)  = (pts-style.pos(), pts-style.named())
 
-  assert(pts.len() >= 2, message: "Catmull-rom curve requires at least two points. Got " + repr(pts.len()) + "instead.")
+  assert(pts.len() >= 2, message: "Catmull-rom curve requires at least two points. Got " + repr(pts.len()) + " instead.")
 
   return (ctx => {
     let (ctx, ..pts) = coordinate.resolve(ctx, ..pts)
@@ -1764,7 +1764,7 @@
 #let hobby(..pts-style, ta: auto, tb: auto, close: false, name: none) = {
   let (pts, style)  = (pts-style.pos(), pts-style.named())
 
-  assert(pts.len() >= 2, message: "Hobby curve requires at least two points. Got " + repr(pts.len()) + "instead.")
+  assert(pts.len() >= 2, message: "Hobby curve requires at least two points. Got " + repr(pts.len()) + " instead.")
 
   return (ctx => {
     let (ctx, ..pts) = coordinate.resolve(ctx, ..pts)


### PR DESCRIPTION
Hi! I have found and fix a small typo/formatting issue in assertion in hobby/catmul that is triggered when you only provide one or zero points. I know this is very minor, so no pressure to approve/merge. 

<img width="616" height="29" alt="image" src="https://github.com/user-attachments/assets/de0591ab-03cd-49df-8cc8-c84b27cbb4a3" />
